### PR TITLE
API PHP Notice Error

### DIFF
--- a/src/Bronto/Api/Row.php
+++ b/src/Bronto/Api/Row.php
@@ -288,14 +288,11 @@ abstract class Bronto_Api_Row implements ArrayAccess, IteratorAggregate
      */
     public function _persist($type, $defaultIndex = false)
     {
+        $data = array();
         $tempPrimaryKey = $this->_primary;
         if (!empty($this->{$tempPrimaryKey})) {
             $index = $this->{$tempPrimaryKey};
-            if ($type === 'delete') {
-                $data = array($this->_primary => $this->{$tempPrimaryKey});
-            } else {
-                $data = array_merge(array($this->_primary => $this->{$tempPrimaryKey}), $data);
-            }
+            $data  = array($this->_primary => $this->{$tempPrimaryKey});
         } else {
             $index = $defaultIndex;
         }


### PR DESCRIPTION
Fixed logic for code that could potentially miss variable creation then try to send that undeclared variable into a method that typehints for an array.  This also fixed a couple lines of code that effectively do the same thing, except one line was trying to merge an undeclared variable with an array and was throwing a PHP NOTICE error.
