### PR TITLE
Updated composer.json to have a correct minimum-stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,5 @@
         }
     },
     "target-dir"       : "Symfony/Component/Console",
-    "minimum-stability": "dist"
+    "minimum-stability": "stable"
 }


### PR DESCRIPTION
I added the repository to packagist however it found this error in the composer.json:

"Reading composer.json of bronto/bronto-api-php-client (atlanticbt)
Skipped branch atlanticbt, no composer file
Reading composer.json of bronto/bronto-api-php-client (master)
Importing branch master (dev-master)
Skipped branch master, Invalid package information: 
minimum-stability : invalid value (dist), must be one of stable, RC, beta, alpha, dev"
