### PR TITLE
autoload.php.dist - fix ClassLoader

### DIFF
--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -9,24 +9,19 @@ if (file_exists($file = __DIR__.'/functions.php')) {
     require_once $file;
 }
 
-require_once BASE_PATH . '/vendor/symfony/src/Symfony/Component/ClassLoader/UniversalClassLoader.php';
-require_once BASE_PATH . '/vendor/symfony/src/Symfony/Component/ClassLoader/ApcUniversalClassLoader.php';
+require_once BASE_PATH . '/vendor/symfony/src/Symfony/Component/ClassLoader/ClassLoader.php';
+require_once BASE_PATH . '/vendor/symfony/src/Symfony/Component/ClassLoader/ApcClassLoader.php';
 
-use Symfony\Component\ClassLoader\UniversalClassLoader;
-use Symfony\Component\ClassLoader\ApcUniversalClassLoader;
+use Symfony\Component\ClassLoader\ClassLoader;
+use Symfony\Component\ClassLoader\ApcClassLoader;
 
 if (extension_loaded('apc')) {
-    $loader = new ApcUniversalClassLoader('bronto.');
+    $loader = new ApcClassLoader('bronto.');
 } else {
-    $loader = new UniversalClassLoader();
+    $loader = new ClassLoader();
 }
 
-$loader->registerNamespaces(array(
-    'Console' => BASE_PATH . '/bin',
-    'Symfony' => BASE_PATH . '/vendor/symfony/src',
-));
-
-$loader->registerPrefixes(array(
+$loader->addPrefixes(array(
     'Bronto_Tests' => BASE_PATH . '/tests',
     'Bronto_'      => BASE_PATH . '/src',
 ));


### PR DESCRIPTION
The Symfony project has [removed the `UniversalClassLoader` component](https://github.com/symfony/ClassLoader/commit/2ae376a83b03004c8427b414ba4ba1b394179889). The current autoload.php.dist is broken because of this. I had to make the attached edits to get this to work.  (I'm generally unfamiliar with autoloading and namespaces, but there doesn't appear to be an equivalent functionality in the `ClassLoader` class to the following chunk of code, so I just took it out.)

```php
$loader->registerNamespaces(array(
    'Console' => BASE_PATH . '/bin',
    'Symfony' => BASE_PATH . '/vendor/symfony/src',
));
```