### PR TITLE
Fix composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,5 @@
   "scripts": {
     "test": "phpunit"
   },
-  "target-dir": "Symfony/Component/Console",
   "minimum-stability": "stable"
 }


### PR DESCRIPTION
target-dir prevents this package from being required via a project's composer.json.