### PR TITLE
fix docs to use correct static class for transactional type email

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ $deliveryObject = $bronto->getDeliveryObject();
 /* @var $delivery \Bronto_Api_Delivery_Row */
 $delivery = $deliveryObject->createRow();
 $delivery->start      = date('c'); // Today
-$delivery->type       = \Bronto_Api_Delivery_Row::TYPE_TRANSACTIONAL;
+$delivery->type       = \Bronto_Api_Delivery::TYPE_TRANSACTIONAL;
 $delivery->messageId  = $message->id;
 $delivery->fromEmail  = 'user@example.com';
 $delivery->fromName   = 'Example Sender';


### PR DESCRIPTION
The `TYPE_TRANSACTIONAL` constant is available on the `Bronto_Api_Delivery` class, not the `Bronto_Api_Delivery_Row` class.
